### PR TITLE
Suggest fixing typo of class name

### DIFF
--- a/Drrrible/Sources/Views/BaseTableViewCell.swift
+++ b/Drrrible/Sources/Views/BaseTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import RxSwift
 
-class BaseTableViewViewCell: UITableViewCell {
+class BaseTableViewCell: UITableViewCell {
 
   // MARK: Initializing
 

--- a/Drrrible/Sources/Views/SettingItemCell.swift
+++ b/Drrrible/Sources/Views/SettingItemCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import ReactorKit
 
-final class SettingItemCell: BaseTableViewViewCell, View {
+final class SettingItemCell: BaseTableViewCell, View {
 
   // MARK: Initializing
 


### PR DESCRIPTION
I found a type issue a when I follow your code base, and that's why I suggest this PR.

I guess this is not your intention because of the file name. (BaseTableViewViewCell class in BaseTableViewCell.swift)